### PR TITLE
Add Early Stopping Mechanism

### DIFF
--- a/pydeepflow/__init__.py
+++ b/pydeepflow/__init__.py
@@ -6,7 +6,8 @@ from .model import Multi_Layer_ANN, Plotting_Utils
 from .learning_rate_scheduler import LearningRateScheduler
 from .checkpoints import ModelCheckpoint
 from .regularization import Regularization
+from .early_stopping import EarlyStopping
 
 _all_ = ["activation", "activation_derivative", "get_loss_function", "get_loss_derivative", "Device",
          "Multi_Layer_ANN", "Plotting_Utils", "LearningRateScheduler", "ModelCheckpoint", "Regularization",
-         "Plotting_Utils"]
+         "Plotting_Utils", "EarlyStopping"]

--- a/pydeepflow/early_stopping.py
+++ b/pydeepflow/early_stopping.py
@@ -23,7 +23,7 @@ class EarlyStopping:
         score = - val_loss
         if self.best_score is None:
             self.best_score = score
-        elif score < self.best_score + self.delta:
+        elif score <= self.best_score + self.delta:
             self.counter+=1
             if self.counter > self.patience:
                 self.early_stop = True

--- a/pydeepflow/early_stopping.py
+++ b/pydeepflow/early_stopping.py
@@ -1,0 +1,18 @@
+class EarlyStopping:
+    def __init__(self, patience:int = 5, delta:int = 0) -> None:
+        self.patience = patience
+        self.delta = delta
+        self.early_stop = False
+        self.best_score = None
+        self.counter = 0
+    def __call__(self, val_loss:float) -> None:
+        score = - val_loss
+        if self.best_score is None:
+            self.best_score = score
+        elif score < self.best_score + self.delta:
+            self.counter+=1
+            if self.counter > self.patience:
+                self.early_stop = True
+        else:
+            self.best_score = score
+            self.counter = 0

--- a/pydeepflow/early_stopping.py
+++ b/pydeepflow/early_stopping.py
@@ -1,11 +1,25 @@
 class EarlyStopping:
-    def __init__(self, patience:int = 5, delta:int = 0) -> None:
+    """Early stops the training if validation loss doesn't improve after a given patience."""
+    def __init__(self, patience:int = 5, delta:float = 0) -> None:
+        """
+        Initializes the EarlyStopping.
+        
+        :param patience (int): How long to wait after last time validation loss improved.
+                               Default: 5
+        :param delta (float): Minimum change in the monitored quantity to qualify as an improvement.
+                              Default: 0
+        """
         self.patience = patience
         self.delta = delta
         self.early_stop = False
         self.best_score = None
         self.counter = 0
     def __call__(self, val_loss:float) -> None:
+        """
+        Checks if the condition for early stopping are met and updates early_stop flag
+        
+        :param val_loss (float): The current validation loss.
+        """
         score = - val_loss
         if self.best_score is None:
             self.best_score = score

--- a/pydeepflow/model.py
+++ b/pydeepflow/model.py
@@ -102,10 +102,12 @@ class Multi_Layer_ANN:
         # Apply L2 regularization to the weights
         self.weights[i] -= learning_rate * self.regularization.apply_l2_regularization(self.weights[i], learning_rate, X.shape)
 
-    def fit(self, epochs, learning_rate=0.01, lr_scheduler=None, X_val=None, y_val=None, checkpoint=None):   
+    def fit(self, epochs, learning_rate=0.01, lr_scheduler=None, early_stop = None, X_val=None, y_val=None, checkpoint=None):   
         """
         Trains the model for a given number of epochs with an optional learning rate scheduler.
         """
+        if early_stop:
+            assert X_val is not None and y_val is not None, "Validation set is required for early stopping"
 
         for epoch in tqdm(range(epochs), desc="Training Progress", ncols=100, ascii="░▒█", colour='green'):
             start_time = time.time()
@@ -152,6 +154,15 @@ class Multi_Layer_ANN:
                 print(f"Epoch {epoch + 1}/{epochs} Train Loss: {train_loss:.4f} Accuracy: {train_accuracy * 100:.2f}% "
                       f"Val Loss: {val_loss:.4f} Val Accuracy: {val_accuracy * 100:.2f}% Time: {epoch_time:.2f}s "
                       f"Learning Rate: {current_lr:.6f}")
+                
+            # Early stopping 
+            early_stop(val_loss)
+            if early_stop.early_stop:
+                print('\n',"#"*150,'\n\n', "early stop at - "
+                      f"Epoch {epoch + 1}/{epochs} Train Loss: {train_loss:.4f} Accuracy: {train_accuracy * 100:.2f}% "
+                      f"Val Loss: {val_loss:.4f} Val Accuracy: {val_accuracy * 100:.2f}% Time: {epoch_time:.2f}s "
+                      f"Learning Rate: {current_lr:.6f}",'\n\n', "#"*150)
+                break
                 
         print("Training Completed!")
         

--- a/pydeepflow/model.py
+++ b/pydeepflow/model.py
@@ -102,14 +102,15 @@ class Multi_Layer_ANN:
         # Apply L2 regularization to the weights
         self.weights[i] -= learning_rate * self.regularization.apply_l2_regularization(self.weights[i], learning_rate, X.shape)
 
-    def fit(self, epochs, learning_rate=0.01, lr_scheduler=None, early_stop = None, X_val=None, y_val=None, checkpoint=None):   
+    def fit(self, epochs, learning_rate=0.01, lr_scheduler=None, early_stop = None, X_val=None, y_val=None, checkpoint=None, verbose=False):   
         """
         Trains the model for a given number of epochs with an optional learning rate scheduler.
+        :param verbose (bool): toggle verbosity during training
         """
         if early_stop:
             assert X_val is not None and y_val is not None, "Validation set is required for early stopping"
 
-        for epoch in tqdm(range(epochs), desc="Training Progress", ncols=100, ascii="░▒█", colour='green'):
+        for epoch in tqdm(range(epochs), desc="Training Progress", ncols=100, ascii="░▒█", colour='green',disable=verbose):
             start_time = time.time()
 
             # Adjust the learning rate using the scheduler if provided
@@ -149,18 +150,19 @@ class Multi_Layer_ANN:
                     checkpoint.save_weights(epoch, self.weights, self.biases, val_loss)
 
             # Log training progress
-            epoch_time = time.time() - start_time
-            if epoch % 10 == 0:
-                print(f"Epoch {epoch + 1}/{epochs} Train Loss: {train_loss:.4f} Accuracy: {train_accuracy * 100:.2f}% "
-                      f"Val Loss: {val_loss:.4f} Val Accuracy: {val_accuracy * 100:.2f}% Time: {epoch_time:.2f}s "
-                      f"Learning Rate: {current_lr:.6f}")
+            if verbose:
+                epoch_time = time.time() - start_time
+                if epoch % 10 == 0:
+                    print(f"Epoch {epoch + 1}/{epochs} Train Loss: {train_loss:.4f} Accuracy: {train_accuracy * 100:.2f}% "
+                        f"Val Loss: {val_loss:.4f} Val Accuracy: {val_accuracy * 100:.2f}% Time: {epoch_time:.2f}s "
+                        f"Learning Rate: {current_lr:.6f}")
                 
             # Early stopping 
             early_stop(val_loss)
             if early_stop.early_stop:
                 print('\n',"#"*150,'\n\n', "early stop at - "
                       f"Epoch {epoch + 1}/{epochs} Train Loss: {train_loss:.4f} Accuracy: {train_accuracy * 100:.2f}% "
-                      f"Val Loss: {val_loss:.4f} Val Accuracy: {val_accuracy * 100:.2f}% Time: {epoch_time:.2f}s "
+                      f"Val Loss: {val_loss:.4f} Val Accuracy: {val_accuracy * 100:.2f}% "
                       f"Learning Rate: {current_lr:.6f}",'\n\n', "#"*150)
                 break
                 

--- a/runner.py
+++ b/runner.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from pydeepflow.model import Multi_Layer_ANN
+from pydeepflow.early_stopping import EarlyStopping
 from pydeepflow.checkpoints import ModelCheckpoint
 from pydeepflow.learning_rate_scheduler import LearningRateScheduler
 from pydeepflow.model import Plotting_Utils  # Correct import
@@ -47,11 +48,13 @@ if __name__ == "__main__":
     # Set up model checkpointing
     checkpoint = ModelCheckpoint(save_dir='./checkpoints', monitor='val_loss', save_best_only=True, save_freq=5)
 
-    # Learning Rate Scheduler
+    # CallBack Functions 
     lr_scheduler = LearningRateScheduler(initial_lr=0.01, strategy="cyclic")
+    early_stop = EarlyStopping(patience=3)
 
     # Train the model and capture history
-    ann.fit(epochs=1000, learning_rate=0.01, lr_scheduler=lr_scheduler, X_val=X_train, y_val=y_train, checkpoint=checkpoint)
+    # increased num epochc to trigger early stopping
+    ann.fit(epochs=10000, learning_rate=0.01, lr_scheduler=lr_scheduler,early_stop=early_stop, X_val=X_train, y_val=y_train, checkpoint=checkpoint)
 
     # Use Plotting_Utils to plot accuracy and loss
     plot_utils = Plotting_Utils()  


### PR DESCRIPTION
### Implement Early Stopping to Prevent Overfitting and Optimize Training
## Closes #10 
### **Description**:
This pull request implements an **EarlyStopping** feature to halt training when there is no significant improvement in validation loss, helping to prevent overfitting and reduce unnecessary computation.

### **Implementation**:
- Added an `EarlyStopping` class that monitors validation loss during training.
- Introduced a `patience` parameter to define how many epochs to wait after the last improvement before stopping training.
- Included feedback to the user about whether early stopping was triggered and at which epoch.

### **Key Changes**:
1. **New `EarlyStopping` class**:
   - Parameters:
     - `patience`: Number of epochs to wait for validation loss improvement.
     - `delta`: Minimum change to qualify as an improvement.
   - Functionality: Stops training when no significant validation loss improvement is detected after the given patience period.
   
2. **Training Loop Update**:
   - Integrated the `EarlyStopping` callback into the training loop, checking for improvements in validation loss after each epoch.
   - Added logging to notify users when early stopping is activated.

3. **Verbosity toggle**:
   - Integrated the `verbosity` param into the training loop
   - It can toggle between showing progress bar, or printing verbose log of each epoch during training

---

### **Testing**:
- Manually tested the early stopping functionality on a sample model with varying patience values.
- Verified that early stopping is triggered after the specified patience period without significant validation loss improvement.

---

### **Additional Notes**:
- Can be further enhanced to work with other metrics beyond validation loss in future iterations.

--- 