### PR TITLE
Implement Gradient Clipping

### DIFF
--- a/pydeepflow/device.py
+++ b/pydeepflow/device.py
@@ -266,3 +266,30 @@ class Device:
             The maximum value(s) in `x` along the specified axis.
         """
         return cp.max(x, axis=axis, keepdims=keepdims) if self.use_gpu else np.max(x, axis=axis, keepdims=keepdims)
+    
+    def norm(self, x, ord=None, axis=None, keepdims=False):
+        """
+        Matrix or vector norm.
+
+        This function is able to return one of eight different matrix norms,
+        or one of an infinite number of vector norms (described below), depending
+        on the value of the ``ord`` parameter.
+
+        Parameters
+        ----------
+        x : np.ndarray or cp.ndarray
+            Input array.
+        ord : {non-zero int, inf, -inf, 'fro', 'nuc'}, optional (default=None)
+            Order of the norm.
+        axis :int or None, optional (default=None)
+            Axis along which to find the norm.
+        keepdims : bool, optional (default=False)
+            Whether to keep the reduced dimensions.
+
+        Returns:
+        --------
+        float or np.ndarray or cp.ndarray
+            Norm of matrix or vector(s).
+        """
+
+        return cp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims) if self.use_gpu else np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)

--- a/runner.py
+++ b/runner.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     # Train the model and capture history
     # increased num epochc to trigger early stopping
-    ann.fit(epochs=10000, learning_rate=0.01, lr_scheduler=lr_scheduler,early_stop=early_stop, X_val=X_train, y_val=y_train, checkpoint=checkpoint)
+    ann.fit(epochs=10000, learning_rate=0.01, lr_scheduler=lr_scheduler,early_stop=early_stop, X_val=X_train, y_val=y_train, checkpoint=checkpoint,clipping_threshold=1)
 
     # Use Plotting_Utils to plot accuracy and loss
     plot_utils = Plotting_Utils()  


### PR DESCRIPTION
### Add Gradient Clipping
## Closes #12 
### **Description**:
This PR introduces **gradient clipping** feature to prevent the issue of exploding gradients during backpropagation. By limiting the magnitude of gradient updates, we aim to stabilize training, improve convergence, and allow users to customize the clipping thresholds based on their specific needs.

### **Implementation**:
- Added an `clipping_threshold` parameter to the fit function which allows users to specify the maximum allowable norm for gradients, ensuring that the magnitude of gradient updates does not exceed this value. Defaults to None in which case gradient clipping is not applied.
- Clipping logic has been added to the `backpropagation()` function, ensuring that gradients are clipped before being used to update model parameters.
   
---

### **Testing**:
- Manually tested the gradient clipping functionality on a sample model with varying patience values.
- Verified that gradient clipping is triggered and the model parameters are being updated correctly.

---