### PR TITLE
fix: set matplotlib backend to 'Agg' for headless environments

### DIFF
--- a/Notebooks/Iris_Load_and_Save.py
+++ b/Notebooks/Iris_Load_and_Save.py
@@ -3,7 +3,7 @@ import os
 
 # Get the current directory of the notebook and go up to the project root
 current_dir = os.getcwd()  # Get the current working directory
-project_root = os.path.abspath(os.path.join(current_dir, '..'))
+project_root = os.path.abspath(os.path.join(current_dir, ".."))
 print(project_root)
 sys.path.append(project_root)
 
@@ -15,11 +15,15 @@ from model import Multi_Layer_ANN
 
 
 url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"
-df = pd.read_csv(url, header=None, names=["sepal_length", "sepal_width", "petal_length", "petal_width", "species"])
+df = pd.read_csv(
+    url,
+    header=None,
+    names=["sepal_length", "sepal_width", "petal_length", "petal_width", "species"],
+)
 
 print(df.head())
 
-df['species'] = df['species'].astype('category').cat.codes
+df["species"] = df["species"].astype("category").cat.codes
 
 
 X = df.iloc[:, :-1].values
@@ -27,7 +31,9 @@ y = df.iloc[:, -1].values
 
 y_one_hot = np.eye(len(np.unique(y)))[y]
 
-X_train, X_test, y_train, y_test = train_test_split(X, y_one_hot, test_size=0.2, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y_one_hot, test_size=0.2, random_state=42
+)
 
 scaler = StandardScaler()
 X_train = scaler.fit_transform(X_train)
@@ -36,9 +42,11 @@ X_test = scaler.transform(X_test)
 
 # Define the architecture
 hidden_layers = [5, 5]
-activations = ['relu', 'relu']
+activations = ["relu", "relu"]
 
-ann = Multi_Layer_ANN(X_train, y_train, hidden_layers, activations, loss='categorical_crossentropy')
+ann = Multi_Layer_ANN(
+    X_train, y_train, hidden_layers, activations, loss="categorical_crossentropy"
+)
 ann.fit(epochs=1000, learning_rate=0.01)
 
 # Make predictions
@@ -55,11 +63,13 @@ print(f"Test Accuracy: {accuracy * 100:.2f}%")
 
 
 # After training your model
-ann.save_model('my_ann_model.pkl')
+ann.save_model("my_ann_model.pkl")
 
 # To load the model later
-ann_loaded = Multi_Layer_ANN(X_train, y_train, hidden_layers, activations, loss='categorical_crossentropy')
-ann_loaded.load_model('my_ann_model.pkl')
+ann_loaded = Multi_Layer_ANN(
+    X_train, y_train, hidden_layers, activations, loss="categorical_crossentropy"
+)
+ann_loaded.load_model("my_ann_model.pkl")
 
 print("After Loading...")
 print(ann_loaded.predict(X_test))

--- a/Notebooks/Iris_Multi_Class.py
+++ b/Notebooks/Iris_Multi_Class.py
@@ -3,7 +3,7 @@ import os
 
 # Get the current directory of the notebook and go up to the project root
 current_dir = os.getcwd()  # Get the current working directory
-project_root = os.path.abspath(os.path.join(current_dir, '..'))
+project_root = os.path.abspath(os.path.join(current_dir, ".."))
 print(project_root)
 sys.path.append(project_root)
 
@@ -15,11 +15,15 @@ from model import Multi_Layer_ANN
 
 
 url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"
-df = pd.read_csv(url, header=None, names=["sepal_length", "sepal_width", "petal_length", "petal_width", "species"])
+df = pd.read_csv(
+    url,
+    header=None,
+    names=["sepal_length", "sepal_width", "petal_length", "petal_width", "species"],
+)
 
 print(df.head())
 
-df['species'] = df['species'].astype('category').cat.codes
+df["species"] = df["species"].astype("category").cat.codes
 
 
 X = df.iloc[:, :-1].values
@@ -27,7 +31,9 @@ y = df.iloc[:, -1].values
 
 y_one_hot = np.eye(len(np.unique(y)))[y]
 
-X_train, X_test, y_train, y_test = train_test_split(X, y_one_hot, test_size=0.2, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y_one_hot, test_size=0.2, random_state=42
+)
 
 scaler = StandardScaler()
 X_train = scaler.fit_transform(X_train)
@@ -36,9 +42,11 @@ X_test = scaler.transform(X_test)
 
 # Define the architecture
 hidden_layers = [5, 5]
-activations = ['relu', 'relu']
+activations = ["relu", "relu"]
 
-ann = Multi_Layer_ANN(X_train, y_train, hidden_layers, activations, loss='categorical_crossentropy')
+ann = Multi_Layer_ANN(
+    X_train, y_train, hidden_layers, activations, loss="categorical_crossentropy"
+)
 ann.fit(epochs=1000, learning_rate=0.01)
 
 # Make predictions
@@ -52,5 +60,3 @@ y_test_labels = np.argmax(y_test, axis=1)
 # Calculate accuracy
 accuracy = np.mean(y_pred == y_test_labels)
 print(f"Test Accuracy: {accuracy * 100:.2f}%")
-
-

--- a/checkGridSearchCV.py
+++ b/checkGridSearchCV.py
@@ -1,16 +1,24 @@
 import numpy as np
 from pydeepflow.gridSearch import GridSearchCV
 from pydeepflow.model import Multi_Layer_ANN
-    
+
 X_train = np.random.rand(100, 20)  # Example feature data
 Y_train = np.random.randint(0, 2, size=(100, 1))  # Example binary labels
 
 param_grid = {
-    'hidden_layers': [[5,5], [20,20], [10, 10]],  # Different configurations of hidden layers
-    'activations': [['relu','relu'], ['tanh','relu'], ['sigmoid','relu']],  # Different activation functions
-    'l2_lambda': [0.0, 0.01],  # Different regularization strengths
-    'dropout_rate': [0.0, 0.5]  # Different dropout rates
+    "hidden_layers": [
+        [5, 5],
+        [20, 20],
+        [10, 10],
+    ],  # Different configurations of hidden layers
+    "activations": [
+        ["relu", "relu"],
+        ["tanh", "relu"],
+        ["sigmoid", "relu"],
+    ],  # Different activation functions
+    "l2_lambda": [0.0, 0.01],  # Different regularization strengths
+    "dropout_rate": [0.0, 0.5],  # Different dropout rates
 }
 
-grid_search = GridSearchCV(Multi_Layer_ANN, param_grid, scoring='accuracy', cv=3)
+grid_search = GridSearchCV(Multi_Layer_ANN, param_grid, scoring="accuracy", cv=3)
 grid_search.fit(X_train, Y_train)

--- a/pydeepflow/__init__.py
+++ b/pydeepflow/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     "ModelCheckpoint",
     "Regularization",
     "EarlyStopping",
-    "CrossValidator",  
+    "CrossValidator",
     "BatchNormalization",
     "GridSearchCV",
 ]

--- a/pydeepflow/activations.py
+++ b/pydeepflow/activations.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def activation(x, func, device, alpha=0.01):
     """
     Applies the specified activation function to the input data.
@@ -52,51 +53,54 @@ def activation(x, func, device, alpha=0.01):
     - Hardshrink: Similar to Softshrink but with hard cutoffs at alpha and -alpha.
     - Softmax: Maps input to a probability distribution by exponentiating and normalizing the inputs.
     """
-    if func == 'relu':
+    if func == "relu":
         return device.maximum(0, x)
-    elif func == 'leaky_relu':
+    elif func == "leaky_relu":
         return device.where(x > 0, x, alpha * x)
-    elif func == 'prelu':
+    elif func == "prelu":
         return device.where(x > 0, x, alpha * x)
-    elif func == 'elu':
+    elif func == "elu":
         return device.where(x > 0, x, alpha * (device.exp(x) - 1))
-    elif func == 'gelu':
-        return 0.5 * x * (1 + device.tanh(device.sqrt(2 / np.pi) * (x + 0.044715 * x ** 3))) 
-    elif func == 'swish':
+    elif func == "gelu":
+        return (
+            0.5 * x * (1 + device.tanh(device.sqrt(2 / np.pi) * (x + 0.044715 * x**3)))
+        )
+    elif func == "swish":
         return x / (1 + device.exp(-x))
-    elif func == 'selu':
+    elif func == "selu":
         lam = 1.0507
         alpha_selu = 1.67326
         return lam * device.where(x > 0, x, alpha_selu * (device.exp(x) - 1))
-    elif func == 'softplus':
+    elif func == "softplus":
         return device.log(1 + device.exp(x))
-    elif func == 'mish':
+    elif func == "mish":
         return x * device.tanh(device.log(1 + device.exp(x)))
-    elif func == 'rrelu':
+    elif func == "rrelu":
         return device.where(x > 0, x, alpha * x)
-    elif func == 'hardswish':
+    elif func == "hardswish":
         return x * device.where(x > 3, 1, device.where(x < -3, 0, (x + 3) / 6))
-    elif func == 'sigmoid':
+    elif func == "sigmoid":
         return 1 / (1 + device.exp(-x))
-    elif func == 'softsign':
+    elif func == "softsign":
         return x / (1 + device.abs(x))
-    elif func == 'tanh':
+    elif func == "tanh":
         return device.tanh(x)
-    elif func == 'hardtanh':
+    elif func == "hardtanh":
         return device.where(x > 1, 1, device.where(x < -1, -1, x))
-    elif func == 'hardsigmoid':
+    elif func == "hardsigmoid":
         return device.where(x > 1, 1, device.where(x < -1, 0, (x + 1) / 2))
-    elif func == 'tanhshrink':
+    elif func == "tanhshrink":
         return x - device.tanh(x)
-    elif func == 'softshrink':
+    elif func == "softshrink":
         return device.where(device.abs(x) > alpha, x - alpha * device.sign(x), 0)
-    elif func == 'hardshrink':
+    elif func == "hardshrink":
         return device.where(device.abs(x) > alpha, x, 0)
-    elif func == 'softmax':
+    elif func == "softmax":
         exp_x = device.exp(x - device.max(x, axis=-1, keepdims=True))
         return exp_x / device.sum(exp_x, axis=-1, keepdims=True)
     else:
         raise ValueError(f"Unsupported activation function: {func}")
+
 
 def activation_derivative(x, func, device, alpha=0.01):
     """
@@ -149,51 +153,56 @@ def activation_derivative(x, func, device, alpha=0.01):
     - The Softshrink and Hardshrink derivatives are 1 where |x| > alpha, otherwise 0.
     - The Softmax derivative assumes usage with cross-entropy loss, resulting in softmax(x) * (1 - softmax(x)).
     """
-    if func == 'relu':
+    if func == "relu":
         return device.where(x > 0, 1, 0)
-    elif func == 'leaky_relu':
+    elif func == "leaky_relu":
         return device.where(x > 0, 1, alpha)
-    elif func == 'prelu':
+    elif func == "prelu":
         return device.where(x > 0, 1, alpha)
-    elif func == 'elu':
+    elif func == "elu":
         return device.where(x > 0, 1, alpha * device.exp(x))
-    elif func == 'gelu':
-        return 0.5 * (1 + device.tanh(device.sqrt(2 / device.pi) * (x + 0.044715 * x ** 3))) + \
-               0.5 * x * (1 - device.tanh(device.sqrt(2 / device.pi) * (x + 0.044715 * x ** 3)) ** 2)
-    elif func == 'swish':
+    elif func == "gelu":
+        return 0.5 * (
+            1 + device.tanh(device.sqrt(2 / device.pi) * (x + 0.044715 * x**3))
+        ) + 0.5 * x * (
+            1 - device.tanh(device.sqrt(2 / device.pi) * (x + 0.044715 * x**3)) ** 2
+        )
+    elif func == "swish":
         sigma = 1 / (1 + device.exp(-x))
         return sigma + x * sigma * (1 - sigma)
-    elif func == 'selu':
+    elif func == "selu":
         lam = 1.0507
         alpha_selu = 1.67326
         return lam * device.where(x > 0, 1, alpha_selu * device.exp(x))
-    elif func == 'softplus':
+    elif func == "softplus":
         return 1 / (1 + device.exp(-x))
-    elif func == 'mish':
+    elif func == "mish":
         sp = device.log(1 + device.exp(x))
         tanh_sp = device.tanh(sp)
-        return device.exp(x) * (tanh_sp + x * (1 - tanh_sp ** 2) / sp) / (1 + device.exp(-x))
-    elif func == 'rrelu':
+        return (
+            device.exp(x) * (tanh_sp + x * (1 - tanh_sp**2) / sp) / (1 + device.exp(-x))
+        )
+    elif func == "rrelu":
         return device.where(x > 0, 1, alpha)
-    elif func == 'hardswish':
+    elif func == "hardswish":
         return device.where(x > -3, device.where(x < 3, x / 3 + 0.5, 1), 0)
-    elif func == 'sigmoid':
+    elif func == "sigmoid":
         return x * (1 - x)
-    elif func == 'softsign':
+    elif func == "softsign":
         return 1 / (1 + device.abs(x)) ** 2
-    elif func == 'tanh':
-        return 1 - x ** 2
-    elif func == 'hardtanh':
+    elif func == "tanh":
+        return 1 - x**2
+    elif func == "hardtanh":
         return device.where(device.abs(x) <= 1, 1, 0)
-    elif func == 'hardsigmoid':
+    elif func == "hardsigmoid":
         return device.where(device.abs(x) <= 1, 0.5, 0)
-    elif func == 'tanhshrink':
+    elif func == "tanhshrink":
         return 1 - device.tanh(x) ** 2
-    elif func == 'softshrink':
+    elif func == "softshrink":
         return device.where(device.abs(x) > alpha, 1, 0)
-    elif func == 'hardshrink':
+    elif func == "hardshrink":
         return device.where(device.abs(x) > alpha, 1, 0)
-    elif func == 'softmax':
+    elif func == "softmax":
         return x * (1 - x)
     else:
         raise ValueError(f"Unsupported activation derivative: {func}")

--- a/pydeepflow/batch_normalization.py
+++ b/pydeepflow/batch_normalization.py
@@ -1,11 +1,12 @@
 import numpy as np
 
+
 class BatchNormalization:
     """
     A class that implements Batch Normalization for a layer in a neural network.
-    
+
     Batch Normalization helps stabilize the learning process and accelerate training
-    by normalizing the inputs of each layer. This class can be used during training 
+    by normalizing the inputs of each layer. This class can be used during training
     and inference.
     """
 
@@ -22,18 +23,18 @@ class BatchNormalization:
         self.epsilon = epsilon
         self.momentum = momentum
         self.device = device
-        
+
         self.gamma = self.device.ones((1, layer_size))
         self.beta = self.device.zeros((1, layer_size))
-        
+
         self.running_mean = self.device.zeros((1, layer_size))
         self.running_variance = self.device.ones((1, layer_size))
-    
+
     def normalize(self, Z, training=True):
         """
         Normalizes the input data Z.
 
-        During training, it computes the batch mean and variance, and updates the 
+        During training, it computes the batch mean and variance, and updates the
         running mean and variance. During inference, it uses the running statistics.
 
         Parameters:
@@ -47,18 +48,27 @@ class BatchNormalization:
         if training:
             batch_mean = self.device.mean(Z, axis=0, keepdims=True)
             batch_variance = self.device.var(Z, axis=0, keepdims=True)
-            
-            Z_normalized = (Z - batch_mean) / self.device.sqrt(batch_variance + self.epsilon)
-            
-            self.running_mean = self.momentum * self.running_mean + (1 - self.momentum) * batch_mean
-            self.running_variance = self.momentum * self.running_variance + (1 - self.momentum) * batch_variance
+
+            Z_normalized = (Z - batch_mean) / self.device.sqrt(
+                batch_variance + self.epsilon
+            )
+
+            self.running_mean = (
+                self.momentum * self.running_mean + (1 - self.momentum) * batch_mean
+            )
+            self.running_variance = (
+                self.momentum * self.running_variance
+                + (1 - self.momentum) * batch_variance
+            )
         else:
-            Z_normalized = (Z - self.running_mean) / self.device.sqrt(self.running_variance + self.epsilon)
-        
+            Z_normalized = (Z - self.running_mean) / self.device.sqrt(
+                self.running_variance + self.epsilon
+            )
+
         Z_scaled = self.gamma * Z_normalized + self.beta
-        
+
         return Z_scaled
-    
+
     def backprop(self, Z, dZ, learning_rate):
         """
         Computes the gradients for gamma and beta during backpropagation
@@ -75,8 +85,8 @@ class BatchNormalization:
         """
         dgamma = self.device.sum(dZ * Z, axis=0, keepdims=True)
         dbeta = self.device.sum(dZ, axis=0, keepdims=True)
-        
+
         self.gamma -= learning_rate * dgamma
         self.beta -= learning_rate * dbeta
-        
+
         return dZ

--- a/pydeepflow/checkpoints.py
+++ b/pydeepflow/checkpoints.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 
+
 class ModelCheckpoint:
     def __init__(self, save_dir, monitor="val_loss", save_best_only=True, save_freq=1):
         """
@@ -15,11 +16,10 @@ class ModelCheckpoint:
         self.save_best_only = save_best_only
         self.save_freq = save_freq
         self.best_metric = np.inf if "loss" in monitor else -np.inf
-        self.best_val_loss = float('inf')  # Initial best validation loss
+        self.best_val_loss = float("inf")  # Initial best validation loss
 
     def save_weights(self, epoch, weights, biases, val_loss):
-        
-        """ Saves weights and biases to the specified directory.
+        """Saves weights and biases to the specified directory.
         Args:
             epoch (int): The current epoch number.
             weights (numpy.ndarray): The weights of the model to be saved.
@@ -28,22 +28,21 @@ class ModelCheckpoint:
         Returns:
             None
         """
-        
+
         # Create the directory if it does not exist
         if not os.path.exists(self.save_dir):
             os.makedirs(self.save_dir)  # Create the directory
 
         checkpoint_path = f"{self.save_dir}/checkpoint_epoch_{epoch}.npz"
-        
+
         # Prepare data to save
         data = {}
         for i, (w, b) in enumerate(zip(weights, biases)):
-            data[f'weights_layer_{i}'] = w  
-            data[f'biases_layer_{i}'] = b    
-        
+            data[f"weights_layer_{i}"] = w
+            data[f"biases_layer_{i}"] = b
+
         # Save as .npz file
         np.savez(checkpoint_path, **data)
-
 
     def should_save(self, epoch, metric):
         """
@@ -58,12 +57,11 @@ class ModelCheckpoint:
         """
         if self.save_freq and epoch % self.save_freq == 0:
             if self.save_best_only:
-                if ("loss" in self.monitor and metric < self.best_metric) or \
-                   ("accuracy" in self.monitor and metric > self.best_metric):
+                if ("loss" in self.monitor and metric < self.best_metric) or (
+                    "accuracy" in self.monitor and metric > self.best_metric
+                ):
                     self.best_metric = metric
                     return True
             else:
                 return True
         return False
-
-    

--- a/pydeepflow/cross_validator.py
+++ b/pydeepflow/cross_validator.py
@@ -2,6 +2,7 @@
 import numpy as np
 from sklearn.model_selection import KFold
 
+
 class CrossValidator:
     def __init__(self, n_splits=5):
         """
@@ -42,6 +43,6 @@ class CrossValidator:
         results = {}
         for metric in metrics:
             if metric == "accuracy":
-                results['accuracy'] = np.mean(y_true == y_pred)
-            
+                results["accuracy"] = np.mean(y_true == y_pred)
+
         return results

--- a/pydeepflow/device.py
+++ b/pydeepflow/device.py
@@ -1,20 +1,22 @@
 import numpy as np
+
 try:
     import cupy as cp
 except ImportError:
     cp = None
 
+
 class Device:
     """
-    A utility class to handle computations on either CPU (NumPy) or GPU (CuPy) 
+    A utility class to handle computations on either CPU (NumPy) or GPU (CuPy)
     depending on the user's preference.
 
     Parameters:
     -----------
     use_gpu : bool, optional (default=False)
-        If True, the class uses GPU (CuPy) for array operations. If CuPy is not installed, 
+        If True, the class uses GPU (CuPy) for array operations. If CuPy is not installed,
         it raises an ImportError.
-    
+
     Attributes:
     -----------
     use_gpu : bool
@@ -25,11 +27,13 @@ class Device:
     ValueError
         If `use_gpu=True` but CuPy is not installed.
     """
-    
+
     def __init__(self, use_gpu=False):
         self.use_gpu = use_gpu
         if use_gpu and cp is None:
-            raise ValueError("CuPy is not installed, please install CuPy for GPU support.")
+            raise ValueError(
+                "CuPy is not installed, please install CuPy for GPU support."
+            )
 
     def abs(self, x):
         """
@@ -46,7 +50,6 @@ class Device:
             The absolute value of each element in `x`.
         """
         return cp.abs(x) if self.use_gpu else np.abs(x)
-
 
     def array(self, data):
         """
@@ -193,7 +196,11 @@ class Device:
         np.ndarray or cp.ndarray
             The sum of elements in `x` along the specified axis.
         """
-        return cp.sum(x, axis=axis, keepdims=keepdims) if self.use_gpu else np.sum(x, axis=axis, keepdims=keepdims)
+        return (
+            cp.sum(x, axis=axis, keepdims=keepdims)
+            if self.use_gpu
+            else np.sum(x, axis=axis, keepdims=keepdims)
+        )
 
     def where(self, condition, x, y):
         """
@@ -246,7 +253,7 @@ class Device:
             The natural logarithm of each element in `x`.
         """
         return cp.log(x) if self.use_gpu else np.log(x)
-    
+
     def asnumpy(self, x):
         """
         Converts a CuPy array to a NumPy array, or simply returns the input if it is already a NumPy array.
@@ -281,8 +288,12 @@ class Device:
         np.ndarray or cp.ndarray
             The maximum value(s) in `x` along the specified axis.
         """
-        return cp.max(x, axis=axis, keepdims=keepdims) if self.use_gpu else np.max(x, axis=axis, keepdims=keepdims)
-    
+        return (
+            cp.max(x, axis=axis, keepdims=keepdims)
+            if self.use_gpu
+            else np.max(x, axis=axis, keepdims=keepdims)
+        )
+
     def norm(self, x, ord=None, axis=None, keepdims=False):
         """
         Matrix or vector norm.
@@ -308,7 +319,11 @@ class Device:
             Norm of matrix or vector(s).
         """
 
-        return cp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims) if self.use_gpu else np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        return (
+            cp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+            if self.use_gpu
+            else np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        )
 
     def ones(self, shape):
         """
@@ -325,8 +340,7 @@ class Device:
             An array of ones, either using NumPy or CuPy.
         """
         return cp.ones(shape) if self.use_gpu else np.ones(shape)
-    
-    
+
     def mean(self, x, axis=None, keepdims=False):
         """
         Computes the mean of the input array along the specified axis.
@@ -345,14 +359,18 @@ class Device:
         np.ndarray or cp.ndarray
             The mean of the input array along the specified axis.
         """
-        return cp.mean(x, axis=axis, keepdims=keepdims) if self.use_gpu else np.mean(x, axis=axis, keepdims=keepdims)
+        return (
+            cp.mean(x, axis=axis, keepdims=keepdims)
+            if self.use_gpu
+            else np.mean(x, axis=axis, keepdims=keepdims)
+        )
 
     def var(self, x, axis=None, keepdims=False):
         """
         Computes the variance of an array along a specified axis.
 
         Parameters:
-        ----------- 
+        -----------
         x : np.ndarray or cp.ndarray
             Input array.
         axis : int or None, optional (default=None)
@@ -365,4 +383,8 @@ class Device:
         np.ndarray or cp.ndarray
             The variance of the input array along the specified axis.
         """
-        return cp.var(x, axis=axis, keepdims=keepdims) if self.use_gpu else np.var(x, axis=axis, keepdims=keepdims)
+        return (
+            cp.var(x, axis=axis, keepdims=keepdims)
+            if self.use_gpu
+            else np.var(x, axis=axis, keepdims=keepdims)
+        )

--- a/pydeepflow/early_stopping.py
+++ b/pydeepflow/early_stopping.py
@@ -1,9 +1,10 @@
 class EarlyStopping:
     """Early stops the training if validation loss doesn't improve after a given patience."""
-    def __init__(self, patience:int = 5, delta:float = 0) -> None:
+
+    def __init__(self, patience: int = 5, delta: float = 0) -> None:
         """
         Initializes the EarlyStopping.
-        
+
         :param patience (int): How long to wait after last time validation loss improved.
                                Default: 5
         :param delta (float): Minimum change in the monitored quantity to qualify as an improvement.
@@ -14,17 +15,18 @@ class EarlyStopping:
         self.early_stop = False
         self.best_score = None
         self.counter = 0
-    def __call__(self, val_loss:float) -> None:
+
+    def __call__(self, val_loss: float) -> None:
         """
         Checks if the condition for early stopping are met and updates early_stop flag
-        
+
         :param val_loss (float): The current validation loss.
         """
-        score = - val_loss
+        score = -val_loss
         if self.best_score is None:
             self.best_score = score
         elif score <= self.best_score + self.delta:
-            self.counter+=1
+            self.counter += 1
             if self.counter > self.patience:
                 self.early_stop = True
         else:

--- a/pydeepflow/gridSearch.py
+++ b/pydeepflow/gridSearch.py
@@ -2,8 +2,9 @@ import numpy as np
 from itertools import product
 from pydeepflow.cross_validator import CrossValidator
 
+
 class GridSearchCV:
-    def __init__(self, model_class, param_grid, scoring='accuracy', cv=3):
+    def __init__(self, model_class, param_grid, scoring="accuracy", cv=3):
         """
         Initializes the GridSearchCV class.
 
@@ -38,27 +39,29 @@ class GridSearchCV:
         for params in param_combinations:
             params_dict = dict(zip(param_names, params))
             print(f"Testing parameters: {params_dict}")
-            
+
             fold_scores = []
             # Iterating over the pre-defined folds
             for train_index, val_index in cross_validator.split(X, y):
                 X_train, X_val = X[train_index], X[val_index]
                 y_train, y_val = y[train_index], y[val_index]
-                
+
                 model = self.model_class(X_train, y_train, **params_dict)
                 model.fit(epochs=10)
-                
+
                 results = model.evaluate(X_val, y_val, metrics=[self.scoring])
-                
-                if self.scoring == 'accuracy':
-                    fold_scores.append(results['accuracy'])
-                elif self.scoring == 'loss':
-                    fold_scores.append(-results['loss'])  # Assuming lower loss is better
+
+                if self.scoring == "accuracy":
+                    fold_scores.append(results["accuracy"])
+                elif self.scoring == "loss":
+                    fold_scores.append(
+                        -results["loss"]
+                    )  # Assuming lower loss is better
 
             avg_score = np.mean(fold_scores)
             print(f"Average score for parameters {params_dict}: {avg_score:.4f}")
             print()
-            
+
             # Update best score and parameters if applicable
             if avg_score > self.best_score:
                 self.best_score = avg_score

--- a/pydeepflow/learning_rate_scheduler.py
+++ b/pydeepflow/learning_rate_scheduler.py
@@ -1,10 +1,13 @@
 import numpy as np
 
+
 class LearningRateScheduler:
-    def __init__(self, initial_lr, strategy="decay", decay_rate=0.1, cycle_length=10, min_lr=1e-6):
+    def __init__(
+        self, initial_lr, strategy="decay", decay_rate=0.1, cycle_length=10, min_lr=1e-6
+    ):
         """
         Initializes the LearningRateScheduler.
-        
+
         :param initial_lr: Initial learning rate.
         :param strategy: The strategy to use, either 'decay' or 'cyclic'.
         :param decay_rate: Decay rate for exponential decay.
@@ -21,18 +24,25 @@ class LearningRateScheduler:
     def get_lr(self, epoch):
         """
         Returns the learning rate for the current epoch based on the selected strategy.
-        
+
         :param epoch: The current epoch number.
         :return: The learning rate for the current epoch.
         """
         if self.strategy == "decay":
             # Exponential decay: LR = initial_lr * (decay_rate ^ epoch)
-            lr = self.initial_lr * (self.decay_rate ** epoch)
+            lr = self.initial_lr * (self.decay_rate**epoch)
             return max(lr, self.min_lr)  # Ensure the LR doesn't fall below min_lr
         elif self.strategy == "cyclic":
             # Cyclic learning rate
             cycle_position = epoch % self.cycle_length
-            lr = self.min_lr + (self.initial_lr - self.min_lr) * (1 + np.cos(np.pi * cycle_position / self.cycle_length)) / 2
+            lr = (
+                self.min_lr
+                + (self.initial_lr - self.min_lr)
+                * (1 + np.cos(np.pi * cycle_position / self.cycle_length))
+                / 2
+            )
             return lr
         else:
-            raise ValueError("Invalid learning rate strategy. Choose 'decay' or 'cyclic'.")
+            raise ValueError(
+                "Invalid learning rate strategy. Choose 'decay' or 'cyclic'."
+            )

--- a/pydeepflow/losses.py
+++ b/pydeepflow/losses.py
@@ -2,6 +2,7 @@
 
 # Loss functions using the device abstraction for GPU/CPU support
 
+
 def binary_crossentropy(y_true, y_pred, device):
     """
     Computes the binary crossentropy loss.
@@ -20,7 +21,11 @@ def binary_crossentropy(y_true, y_pred, device):
     float
         The binary crossentropy loss.
     """
-    return -device.mean(y_true * device.log(y_pred + 1e-8) + (1 - y_true) * device.log(1 - y_pred + 1e-8))
+    return -device.mean(
+        y_true * device.log(y_pred + 1e-8)
+        + (1 - y_true) * device.log(1 - y_pred + 1e-8)
+    )
+
 
 def binary_crossentropy_derivative(y_true, y_pred, device):
     """
@@ -42,6 +47,7 @@ def binary_crossentropy_derivative(y_true, y_pred, device):
     """
     return -(y_true / (y_pred + 1e-8)) + (1 - y_true) / (1 - y_pred + 1e-8)
 
+
 def mse(y_true, y_pred, device):
     """
     Computes the Mean Squared Error (MSE) loss.
@@ -61,6 +67,7 @@ def mse(y_true, y_pred, device):
         The Mean Squared Error loss.
     """
     return device.mean((y_true - y_pred) ** 2)
+
 
 def mse_derivative(y_true, y_pred, device):
     """
@@ -82,6 +89,7 @@ def mse_derivative(y_true, y_pred, device):
     """
     return 2 * (y_pred - y_true) / y_true.size
 
+
 def categorical_crossentropy(y_true, y_pred, device):
     """
     Computes the categorical crossentropy loss.
@@ -101,6 +109,7 @@ def categorical_crossentropy(y_true, y_pred, device):
         The categorical crossentropy loss.
     """
     return -device.sum(y_true * device.log(y_pred + 1e-8)) / y_true.shape[0]
+
 
 def categorical_crossentropy_derivative(y_true, y_pred, device):
     """
@@ -122,6 +131,7 @@ def categorical_crossentropy_derivative(y_true, y_pred, device):
     """
     return -y_true / (y_pred + 1e-8)
 
+
 def hinge_loss(y_true, y_pred, device):
     """
     Computes the hinge loss.
@@ -142,6 +152,7 @@ def hinge_loss(y_true, y_pred, device):
     """
     return device.mean(device.maximum(0, 1 - y_true * y_pred))
 
+
 def hinge_loss_derivative(y_true, y_pred, device):
     """
     Computes the derivative of the hinge loss.
@@ -161,6 +172,7 @@ def hinge_loss_derivative(y_true, y_pred, device):
         The derivative of the hinge loss with respect to predictions.
     """
     return device.where(y_true * y_pred < 1, -y_true, 0)
+
 
 def huber_loss(y_true, y_pred, device, delta=1.0):
     """
@@ -188,6 +200,7 @@ def huber_loss(y_true, y_pred, device, delta=1.0):
     linear_loss = delta * (device.abs(error) - 0.5 * delta)
     return device.mean(device.where(is_small_error, squared_loss, linear_loss))
 
+
 def huber_loss_derivative(y_true, y_pred, device, delta=1.0):
     """
     Computes the derivative of the Huber loss.
@@ -212,6 +225,7 @@ def huber_loss_derivative(y_true, y_pred, device, delta=1.0):
     is_small_error = device.abs(error) <= delta
     return device.where(is_small_error, error, delta * device.sign(error))
 
+
 # Get the appropriate loss function
 def get_loss_function(loss_name):
     """
@@ -232,18 +246,19 @@ def get_loss_function(loss_name):
     ValueError
         If the specified loss function is unsupported.
     """
-    if loss_name == 'binary_crossentropy':
+    if loss_name == "binary_crossentropy":
         return binary_crossentropy
-    elif loss_name == 'mse':
+    elif loss_name == "mse":
         return mse
-    elif loss_name == 'categorical_crossentropy':
+    elif loss_name == "categorical_crossentropy":
         return categorical_crossentropy
-    elif loss_name == 'hinge':
+    elif loss_name == "hinge":
         return hinge_loss
-    elif loss_name == 'huber':
+    elif loss_name == "huber":
         return huber_loss
     else:
         raise ValueError(f"Unsupported loss function: {loss_name}")
+
 
 # Get the appropriate loss derivative function
 def get_loss_derivative(loss_name):
@@ -265,15 +280,15 @@ def get_loss_derivative(loss_name):
     ValueError
         If the specified loss derivative function is unsupported.
     """
-    if loss_name == 'binary_crossentropy':
+    if loss_name == "binary_crossentropy":
         return binary_crossentropy_derivative
-    elif loss_name == 'mse':
+    elif loss_name == "mse":
         return mse_derivative
-    elif loss_name == 'categorical_crossentropy':
+    elif loss_name == "categorical_crossentropy":
         return categorical_crossentropy_derivative
-    elif loss_name == 'hinge':
+    elif loss_name == "hinge":
         return hinge_loss_derivative
-    elif loss_name == 'huber':
+    elif loss_name == "huber":
         return huber_loss_derivative
     else:
         raise ValueError(f"Unsupported loss derivative: {loss_name}")

--- a/pydeepflow/main.py
+++ b/pydeepflow/main.py
@@ -5,6 +5,7 @@ from sklearn.preprocessing import StandardScaler
 from pydeepflow.model import Multi_Layer_ANN
 from pydeepflow.cross_validator import CrossValidator  # Import CrossValidator
 
+
 def load_and_preprocess_data(url):
     """
     Loads the Iris dataset from a URL, preprocesses it, and prepares it for training.
@@ -25,11 +26,15 @@ def load_and_preprocess_data(url):
             - y_one_hot (np.ndarray): The one-hot encoded labels.
     """
     # Load the Iris dataset
-    df = pd.read_csv(url, header=None, names=["sepal_length", "sepal_width", "petal_length", "petal_width", "species"])
+    df = pd.read_csv(
+        url,
+        header=None,
+        names=["sepal_length", "sepal_width", "petal_length", "petal_width", "species"],
+    )
     print(df.head())
 
     # Encode species labels to integers
-    df['species'] = df['species'].astype('category').cat.codes
+    df["species"] = df["species"].astype("category").cat.codes
 
     # Split data into features (X) and labels (y)
     X = df.iloc[:, :-1].values
@@ -43,6 +48,7 @@ def load_and_preprocess_data(url):
     X = scaler.fit_transform(X)
 
     return X, y_one_hot
+
 
 if __name__ == "__main__":
     """
@@ -66,18 +72,27 @@ if __name__ == "__main__":
 
     # Ask the user whether to use GPU
     use_gpu_input = input("Use GPU? (y/n): ").strip().lower()
-    use_gpu = True if use_gpu_input == 'y' else False
+    use_gpu = True if use_gpu_input == "y" else False
 
     # Define the architecture of the network
     hidden_layers = [5, 5]
-    activations = ['relu', 'relu']
+    activations = ["relu", "relu"]
 
     # Initialize the ANN with use_gpu option
-    ann = Multi_Layer_ANN(X, y_one_hot, hidden_layers, activations, loss='categorical_crossentropy', use_gpu=use_gpu)
+    ann = Multi_Layer_ANN(
+        X,
+        y_one_hot,
+        hidden_layers,
+        activations,
+        loss="categorical_crossentropy",
+        use_gpu=use_gpu,
+    )
 
     # Initialize CrossValidator and perform K-Fold Cross Validation
     cross_validator = CrossValidator(k=n_splits, metrics=["accuracy"])
-    results = cross_validator.evaluate(ann, X, y_one_hot, epochs=1000, learning_rate=0.01, verbose=True)
+    results = cross_validator.evaluate(
+        ann, X, y_one_hot, epochs=1000, learning_rate=0.01, verbose=True
+    )
 
     # Print cross-validation results
     print("Cross-Validation Results:", results)

--- a/pydeepflow/metrics.py
+++ b/pydeepflow/metrics.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def precision_score(y_true, y_pred):
     """
     Calculates the precision for binary classification.
@@ -18,6 +19,7 @@ def precision_score(y_true, y_pred):
     predicted_positives = np.sum(y_pred == 1)
     precision = true_positives / (predicted_positives + 1e-7)
     return precision
+
 
 def recall_score(y_true, y_pred):
     """
@@ -38,6 +40,7 @@ def recall_score(y_true, y_pred):
     recall = true_positives / (actual_positives + 1e-7)
     return recall
 
+
 def f1_score(y_true, y_pred):
     """
     Calculates the F1-score, which is the harmonic mean of precision and recall.
@@ -56,6 +59,7 @@ def f1_score(y_true, y_pred):
     recall = recall_score(y_true, y_pred)
     f1 = 2 * (precision * recall) / (precision + recall + 1e-7)
     return f1
+
 
 def confusion_matrix(y_true, y_pred, num_classes):
     """

--- a/pydeepflow/optimizers.py
+++ b/pydeepflow/optimizers.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class Adam:
     """
     Adam optimizer.
@@ -14,6 +15,7 @@ class Adam:
         beta2 (float): The exponential decay rate for the second-moment estimates.
         epsilon (float): A small constant for numerical stability.
     """
+
     def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8):
         self.learning_rate = learning_rate
         self.beta1 = beta1
@@ -39,9 +41,10 @@ class Adam:
         for i in range(len(params)):
             self.m[i] = self.beta1 * self.m[i] + (1 - self.beta1) * grads[i]
             self.v[i] = self.beta2 * self.v[i] + (1 - self.beta2) * (grads[i] ** 2)
-            m_hat = self.m[i] / (1 - self.beta1 ** self.t)
-            v_hat = self.v[i] / (1 - self.beta2 ** self.t)
+            m_hat = self.m[i] / (1 - self.beta1**self.t)
+            v_hat = self.v[i] / (1 - self.beta2**self.t)
             params[i] -= self.learning_rate * m_hat / (np.sqrt(v_hat) + self.epsilon)
+
 
 class RMSprop:
     """
@@ -55,6 +58,7 @@ class RMSprop:
         decay_rate (float): The decay rate.
         epsilon (float): A small constant for numerical stability.
     """
+
     def __init__(self, learning_rate=0.001, decay_rate=0.9, epsilon=1e-8):
         self.learning_rate = learning_rate
         self.decay_rate = decay_rate
@@ -73,5 +77,9 @@ class RMSprop:
             self.cache = [np.zeros_like(p) for p in params]
 
         for i in range(len(params)):
-            self.cache[i] = self.decay_rate * self.cache[i] + (1 - self.decay_rate) * (grads[i] ** 2)
-            params[i] -= self.learning_rate * grads[i] / (np.sqrt(self.cache[i]) + self.epsilon)
+            self.cache[i] = self.decay_rate * self.cache[i] + (1 - self.decay_rate) * (
+                grads[i] ** 2
+            )
+            params[i] -= (
+                self.learning_rate * grads[i] / (np.sqrt(self.cache[i]) + self.epsilon)
+            )

--- a/pydeepflow/regularization.py
+++ b/pydeepflow/regularization.py
@@ -1,5 +1,6 @@
-import numpy as np 
+import numpy as np
 from .device import Device
+
 
 class Regularization:
     """
@@ -14,6 +15,7 @@ class Regularization:
         dropout_rate (float): The probability of setting a neuron's output to zero during dropout.
         device (Device): The device (CPU or GPU) on which to perform computations.
     """
+
     def __init__(self, l2_lambda=0.0, dropout_rate=0.0):
         """
         Initializes the Regularization instance.
@@ -65,5 +67,5 @@ class Regularization:
             dropout_mask = self.device.random().rand(*A.shape) > self.dropout_rate
             A *= dropout_mask
         else:
-            A *= (1 - self.dropout_rate)
+            A *= 1 - self.dropout_rate
         return A

--- a/runner.py
+++ b/runner.py
@@ -8,8 +8,8 @@ from pydeepflow.optimizers import Adam, RMSprop
 from pydeepflow.early_stopping import EarlyStopping
 from pydeepflow.checkpoints import ModelCheckpoint
 from pydeepflow.learning_rate_scheduler import LearningRateScheduler
-from pydeepflow.model import Plotting_Utils  
-from pydeepflow.cross_validator import CrossValidator  
+from pydeepflow.model import Plotting_Utils
+from pydeepflow.cross_validator import CrossValidator
 
 if __name__ == "__main__":
 
@@ -30,28 +30,30 @@ if __name__ == "__main__":
 
     # Ask the user whether to use GPU (simulated as False for this example)
     use_gpu_input = False
-    use_gpu = True if use_gpu_input == 'y' else False
+    use_gpu = True if use_gpu_input == "y" else False
 
     # Define the architecture of the network
     hidden_layers = [5, 5]  # Example: two hidden layers with 5 neurons each
-    activations = ['relu', 'relu']  # ReLU activations for the hidden layers
+    activations = ["relu", "relu"]  # ReLU activations for the hidden layers
 
     # Initialize the CrossValidator
-    k_folds = 10 # Set the number of folds for cross-validation
+    k_folds = 10  # Set the number of folds for cross-validation
     cross_validator = CrossValidator(n_splits=k_folds)
 
     # Perform k-fold cross-validation
     fold_accuracies = []  # To store accuracy for each fold
     optimizer_choice = input("Choose optimizer (sgd, adam, rmsprop): ").lower()
 
-    if optimizer_choice == 'adam':
+    if optimizer_choice == "adam":
         optimizer = Adam()
-    elif optimizer_choice == 'rmsprop':
+    elif optimizer_choice == "rmsprop":
         optimizer = RMSprop()
     else:
         optimizer = None  # Default to SGD
 
-    for fold, (train_index, val_index) in enumerate(cross_validator.split(X, y_one_hot)):
+    for fold, (train_index, val_index) in enumerate(
+        cross_validator.split(X, y_one_hot)
+    ):
         print(f"Training on fold {fold + 1}/{k_folds}")
 
         # Split data into training and validation sets for the current fold
@@ -59,34 +61,51 @@ if __name__ == "__main__":
         y_train, y_val = y_one_hot[train_index], y_one_hot[val_index]
 
         # Initialize the ANN for each fold without batch normalization
-        ann = Multi_Layer_ANN(X_train, y_train, hidden_layers, activations,
-                              loss='categorical_crossentropy', use_gpu=use_gpu, optimizer=optimizer)
+        ann = Multi_Layer_ANN(
+            X_train,
+            y_train,
+            hidden_layers,
+            activations,
+            loss="categorical_crossentropy",
+            use_gpu=use_gpu,
+            optimizer=optimizer,
+        )
 
         # Callback functions
         lr_scheduler = LearningRateScheduler(initial_lr=0.01, strategy="cyclic")
 
         # Train the model and capture history
-        ann.fit(epochs=1000, learning_rate=0.01, 
-                lr_scheduler=lr_scheduler, 
-                X_val=X_val, 
-                y_val=y_val, 
-                verbose=True)
+        ann.fit(
+            epochs=1000,
+            learning_rate=0.01,
+            lr_scheduler=lr_scheduler,
+            X_val=X_val,
+            y_val=y_val,
+            verbose=True,
+        )
 
         # Evaluate the model on the validation set
         # Evaluate the model on the validation set
-        metrics_to_eval = ['loss', 'accuracy', 'precision', 'recall', 'f1_score', 'confusion_matrix']
+        metrics_to_eval = [
+            "loss",
+            "accuracy",
+            "precision",
+            "recall",
+            "f1_score",
+            "confusion_matrix",
+        ]
         results = ann.evaluate(X_val, y_val, metrics=metrics_to_eval)
-        
-        fold_accuracies.append(results['accuracy'])
-        
+
+        fold_accuracies.append(results["accuracy"])
+
         print(f"Fold {fold + 1} Metrics:")
         for metric_name, metric_value in results.items():
-            if metric_name == 'confusion_matrix':
+            if metric_name == "confusion_matrix":
                 print(f"  {metric_name.capitalize()}:")
                 print(metric_value)
             else:
                 print(f"  {metric_name.capitalize()}: {metric_value:.4f}")
 
     # Optionally plot training history of the last fold
-    # plot_utils = Plotting_Utils()  
-    # plot_utils.plot_training_history(ann.history)
+    plot_utils = Plotting_Utils()
+    plot_utils.plot_training_history(ann.history)

--- a/setup.py
+++ b/setup.py
@@ -20,23 +20,23 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",  # Additional metadata
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     install_requires=[
-        "numpy>=1.23.5",  
+        "numpy>=1.23.5",
         "pandas>=1.5.3",
         "scikit-learn>=1.2.0",
         "jupyter>=1.0.0",
         "tqdm>=4.64.1",
         "colorama>=0.4.6",
-        'matplotlib',
+        "matplotlib",
     ],
     extras_require={
         "gpu": ["cupy>=9.6.0"],  # Optional GPU support
         "testing": ["pytest>=6.2.5"],  # Dependencies for testing
     },
     entry_points={
-        'console_scripts': [
-            'pydeepflow-cli=pydeepflow.cli:main',  # CLI tool if applicable
+        "console_scripts": [
+            "pydeepflow-cli=pydeepflow.cli:main",  # CLI tool if applicable
         ],
     },
     keywords="deep-learning artificial-intelligence neural-networks tensorflow pytorch",  # Add relevant keywords
@@ -44,6 +44,6 @@ setup(
     project_urls={
         "Bug Tracker": "https://github.com/ravin-d-27/PyDeepFlow/issues",
         "Source Code": "https://github.com/ravin-d-27/PyDeepFlow",
-        "Documentation":"https://github.com/ravin-d-27/PyDeepFlow/wiki"
+        "Documentation": "https://github.com/ravin-d-27/PyDeepFlow/wiki",
     },
 )

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -3,6 +3,7 @@ import numpy as np
 from pydeepflow.activations import activation, activation_derivative
 from pydeepflow.device import Device
 
+
 class TestActivations(unittest.TestCase):
 
     def setUp(self):
@@ -10,182 +11,183 @@ class TestActivations(unittest.TestCase):
 
     def test_relu(self):
         x = np.array([-1, 0, 1])
-        result = activation(x, 'relu', self.device_cpu)
+        result = activation(x, "relu", self.device_cpu)
         expected = np.array([0, 0, 1])
         np.testing.assert_array_equal(result, expected)
 
     def test_leaky_relu(self):
         x = np.array([-1, 0, 1])
-        result = activation(x, 'leaky_relu', self.device_cpu, alpha=0.01)
+        result = activation(x, "leaky_relu", self.device_cpu, alpha=0.01)
         expected = np.array([-0.01, 0, 1])
         np.testing.assert_array_equal(result, expected)
 
     def test_prelu(self):
         x = np.array([-1, 0, 1])
-        result = activation(x, 'prelu', self.device_cpu, alpha=0.01)
+        result = activation(x, "prelu", self.device_cpu, alpha=0.01)
         expected = np.array([-0.01, 0, 1])
         np.testing.assert_array_equal(result, expected)
 
     def test_gelu(self):
         x = np.array([0])
-        result = activation(x, 'gelu', self.device_cpu)
+        result = activation(x, "gelu", self.device_cpu)
         expected = np.array([0])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_elu(self):
         x = np.array([-1, 0, 1])
-        result = activation(x, 'elu', self.device_cpu, alpha=1.0)
+        result = activation(x, "elu", self.device_cpu, alpha=1.0)
         expected = np.array([-0.6321, 0, 1])
         np.testing.assert_array_almost_equal(result, expected, decimal=4)
 
     def test_selu(self):
         x = np.array([-1, 0, 1])
-        result = activation(x, 'selu', self.device_cpu)
+        result = activation(x, "selu", self.device_cpu)
         expected = np.array([-1.1113, 0, 1.0507])
         np.testing.assert_array_almost_equal(result, expected, decimal=4)
 
     def test_mish(self):
         x = np.array([0])
-        result = activation(x, 'mish', self.device_cpu)
+        result = activation(x, "mish", self.device_cpu)
         expected = np.array([0])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_swish(self):
         x = np.array([0])
-        result = activation(x, 'swish', self.device_cpu)
+        result = activation(x, "swish", self.device_cpu)
         expected = np.array([0])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_sigmoid(self):
         x = np.array([0])
-        result = activation(x, 'sigmoid', self.device_cpu)
+        result = activation(x, "sigmoid", self.device_cpu)
         expected = np.array([0.5])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_softsign(self):
         x = np.array([0, 1, -1])
-        result = activation(x, 'softsign', self.device_cpu)
+        result = activation(x, "softsign", self.device_cpu)
         expected = np.array([0, 0.5, -0.5])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_tanh(self):
         x = np.array([0])
-        result = activation(x, 'tanh', self.device_cpu)
+        result = activation(x, "tanh", self.device_cpu)
         expected = np.array([0])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardtanh(self):
         x = np.array([-2, 0, 2])
-        result = activation(x, 'hardtanh', self.device_cpu)
+        result = activation(x, "hardtanh", self.device_cpu)
         expected = np.array([-1, 0, 1])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardswish(self):
         x = np.array([-3, 0, 3])
-        result = activation(x, 'hardswish', self.device_cpu)
+        result = activation(x, "hardswish", self.device_cpu)
         expected = np.array([0, 0, 3])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardsigmoid(self):
         x = np.array([-2, 0, 2])
-        result = activation(x, 'hardsigmoid', self.device_cpu)
+        result = activation(x, "hardsigmoid", self.device_cpu)
         expected = np.array([0, 0.5, 1])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_tanhshrink(self):
         x = np.array([0, 1])
-        result = activation(x, 'tanhshrink', self.device_cpu)
+        result = activation(x, "tanhshrink", self.device_cpu)
         expected = np.array([0, 1 - np.tanh(1)])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_softshrink(self):
         x = np.array([-1.5, -0.5, 0.5, 1.5])
-        result = activation(x, 'softshrink', self.device_cpu, alpha=1.0)
+        result = activation(x, "softshrink", self.device_cpu, alpha=1.0)
         expected = np.array([-0.5, 0, 0, 0.5])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardshrink(self):
         x = np.array([-1.5, -0.5, 0.5, 1.5])
-        result = activation(x, 'hardshrink', self.device_cpu, alpha=1.0)
+        result = activation(x, "hardshrink", self.device_cpu, alpha=1.0)
         expected = np.array([-1.5, 0, 0, 1.5])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_softplus(self):
         x = np.array([0])
-        result = activation(x, 'softplus', self.device_cpu)
+        result = activation(x, "softplus", self.device_cpu)
         expected = np.array([np.log(2)])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_softmax(self):
         x = np.array([[1, 2, 3]])
-        result = activation(x, 'softmax', self.device_cpu)
+        result = activation(x, "softmax", self.device_cpu)
         expected = np.array([[0.09003057, 0.24472847, 0.66524096]])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_rrelu(self):
         x = np.array([-1, 0, 1])
-        result = activation(x, 'rrelu', self.device_cpu, alpha=0.01)
+        result = activation(x, "rrelu", self.device_cpu, alpha=0.01)
         expected = np.array([-0.01, 0, 1])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_invalid_activation(self):
         with self.assertRaises(ValueError):
-            activation(np.array([1, 2, 3]), 'invalid', self.device_cpu)
+            activation(np.array([1, 2, 3]), "invalid", self.device_cpu)
 
     # Derivative Tests
     def test_relu_derivative(self):
         x = np.array([-1, 0, 1])
-        result = activation_derivative(x, 'relu', self.device_cpu)
+        result = activation_derivative(x, "relu", self.device_cpu)
         expected = np.array([0, 0, 1])
         np.testing.assert_array_equal(result, expected)
 
     def test_sigmoid_derivative(self):
         x = np.array([0.5])
-        result = activation_derivative(x, 'sigmoid', self.device_cpu)
+        result = activation_derivative(x, "sigmoid", self.device_cpu)
         expected = np.array([0.25])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_softsign_derivative(self):
         x = np.array([1])
-        result = activation_derivative(x, 'softsign', self.device_cpu)
+        result = activation_derivative(x, "softsign", self.device_cpu)
         expected = np.array([0.25])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_tanh_derivative(self):
         x = np.array([0.5])
-        result = activation_derivative(x, 'tanh', self.device_cpu)
+        result = activation_derivative(x, "tanh", self.device_cpu)
         expected = np.array([0.75])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardtanh_derivative(self):
         x = np.array([-2, 0, 2])
-        result = activation_derivative(x, 'hardtanh', self.device_cpu)
+        result = activation_derivative(x, "hardtanh", self.device_cpu)
         expected = np.array([0, 1, 0])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardsigmoid_derivative(self):
         x = np.array([0])
-        result = activation_derivative(x, 'hardsigmoid', self.device_cpu)
+        result = activation_derivative(x, "hardsigmoid", self.device_cpu)
         expected = np.array([0.5])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_tanhshrink_derivative(self):
         x = np.array([1])
-        result = activation_derivative(x, 'tanhshrink', self.device_cpu)
+        result = activation_derivative(x, "tanhshrink", self.device_cpu)
         expected = np.array([0.419974])
         np.testing.assert_array_almost_equal(result, expected, decimal=5)
 
     def test_softshrink_derivative(self):
         x = np.array([-1.5, -0.5, 0.5, 1.5])
-        result = activation_derivative(x, 'softshrink', self.device_cpu, alpha=1.0)
+        result = activation_derivative(x, "softshrink", self.device_cpu, alpha=1.0)
         expected = np.array([1, 0, 0, 1])
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_hardshrink_derivative(self):
         x = np.array([-1.5, -0.5, 0.5, 1.5])
-        result = activation_derivative(x, 'hardshrink', self.device_cpu, alpha=1.0)
+        result = activation_derivative(x, "hardshrink", self.device_cpu, alpha=1.0)
         expected = np.array([1, 0, 0, 1])
         np.testing.assert_array_almost_equal(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_batch_normalization.py
+++ b/tests/test_batch_normalization.py
@@ -3,6 +3,7 @@ import numpy as np
 from pydeepflow.batch_normalization import BatchNormalization
 from pydeepflow.device import Device
 
+
 class TestBatchNormalization(unittest.TestCase):
     def setUp(self):
         self.device = Device(use_gpu=False)
@@ -23,10 +24,13 @@ class TestBatchNormalization(unittest.TestCase):
 
     def test_backprop(self):
         Z = self.device.array([[1, 2, 3, 4], [4, 3, 2, 1], [5, 6, 7, 8]])
-        dZ = self.device.array([[0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1], [0.5, 0.6, 0.7, 0.8]])
+        dZ = self.device.array(
+            [[0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1], [0.5, 0.6, 0.7, 0.8]]
+        )
         self.bn.normalize(Z, training=True)
         output = self.bn.backprop(Z, dZ, learning_rate=0.01)
         self.assertEqual(output.shape, dZ.shape)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 from pydeepflow.device import Device
 
+
 class TestDevice(unittest.TestCase):
 
     def setUp(self):
@@ -35,6 +36,7 @@ class TestDevice(unittest.TestCase):
         result = self.device_cpu.dot(a, b)
         expected = np.dot(a, b)
         np.testing.assert_array_equal(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -3,6 +3,7 @@ import numpy as np
 from pydeepflow.gridSearch import GridSearchCV
 from pydeepflow.model import Multi_Layer_ANN
 
+
 class TestGridSearchCV(unittest.TestCase):
 
     def setUp(self):
@@ -15,27 +16,33 @@ class TestGridSearchCV(unittest.TestCase):
         Test if GridSearchCV runs, finds best parameters, and the process is consistent.
         """
         param_grid = {
-            'hidden_layers': [[5], [10]],
-            'activations': [['relu']],
-            'l2_lambda': [0.0, 0.01]
+            "hidden_layers": [[5], [10]],
+            "activations": [["relu"]],
+            "l2_lambda": [0.0, 0.01],
         }
 
         grid_search = GridSearchCV(
-            model_class=Multi_Layer_ANN,
-            param_grid=param_grid,
-            scoring='accuracy',
-            cv=2 
+            model_class=Multi_Layer_ANN, param_grid=param_grid, scoring="accuracy", cv=2
         )
 
         grid_search.fit(self.X, self.y)
 
-        self.assertIsNotNone(grid_search.best_params, "best_params should be set after fitting.")
-        self.assertNotEqual(grid_search.best_score, -np.inf, "best_score should be updated after fitting.")
-        self.assertIn(grid_search.best_params['hidden_layers'], param_grid['hidden_layers'])
-        self.assertIn(grid_search.best_params['l2_lambda'], param_grid['l2_lambda'])
+        self.assertIsNotNone(
+            grid_search.best_params, "best_params should be set after fitting."
+        )
+        self.assertNotEqual(
+            grid_search.best_score,
+            -np.inf,
+            "best_score should be updated after fitting.",
+        )
+        self.assertIn(
+            grid_search.best_params["hidden_layers"], param_grid["hidden_layers"]
+        )
+        self.assertIn(grid_search.best_params["l2_lambda"], param_grid["l2_lambda"])
 
         print(f"\nGridSearchCV test passed with best params: {grid_search.best_params}")
         print(f"Best score: {grid_search.best_score:.4f}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -3,6 +3,7 @@ import numpy as np
 from pydeepflow.losses import binary_crossentropy, mse, mse_derivative
 from pydeepflow.device import Device
 
+
 class TestLosses(unittest.TestCase):
 
     def setUp(self):
@@ -12,7 +13,9 @@ class TestLosses(unittest.TestCase):
         y_true = np.array([1, 0, 1])
         y_pred = np.array([0.9, 0.1, 0.8])
         result = binary_crossentropy(y_true, y_pred, self.device_cpu)
-        expected = -np.mean(y_true * np.log(y_pred + 1e-8) + (1 - y_true) * np.log(1 - y_pred + 1e-8))
+        expected = -np.mean(
+            y_true * np.log(y_pred + 1e-8) + (1 - y_true) * np.log(1 - y_pred + 1e-8)
+        )
         self.assertAlmostEqual(result, expected)
 
     def test_mse(self):
@@ -28,6 +31,7 @@ class TestLosses(unittest.TestCase):
         result = mse_derivative(y_true, y_pred, self.device_cpu)
         expected = 2 * (y_pred - y_true) / y_true.size
         np.testing.assert_array_almost_equal(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 from pydeepflow.metrics import precision_score, recall_score, f1_score, confusion_matrix
 
+
 class TestMetrics(unittest.TestCase):
 
     def setUp(self):
@@ -26,7 +27,10 @@ class TestMetrics(unittest.TestCase):
         # TN = 1, FP = 1
         # FN = 1, TP = 3
         expected_matrix = np.array([[1, 1], [1, 3]])
-        np.testing.assert_array_equal(confusion_matrix(self.y_true, self.y_pred, num_classes=2), expected_matrix)
+        np.testing.assert_array_equal(
+            confusion_matrix(self.y_true, self.y_pred, num_classes=2), expected_matrix
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,53 +5,79 @@ from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 
+
 class TestMultiLayerANN(unittest.TestCase):
     def setUp(self):
         # Load and prepare the Iris dataset
         iris = load_iris()
         X = iris.data
         y = iris.target
-        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-        
+        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
+            X, y, test_size=0.2, random_state=42
+        )
+
         # Standardize the features
         scaler = StandardScaler()
         self.X_train = scaler.fit_transform(self.X_train)
         self.X_test = scaler.transform(self.X_test)
-        
+
         # One-hot encode the labels
         self.y_train = np.eye(3)[self.y_train]
         self.y_test = np.eye(3)[self.y_test]
+
     def test_model_with_batch_norm(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[10, 10], 
-                                activations=['relu', 'relu'], use_batch_norm=True)
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[10, 10],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+        )
         model.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         results = model.evaluate(self.X_test, self.y_test)
-        self.assertGreater(results['accuracy'], 0.8)
+        self.assertGreater(results["accuracy"], 0.8)
 
     def test_model_without_batch_norm(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[10, 10], 
-                                activations=['relu', 'relu'], use_batch_norm=False)
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[10, 10],
+            activations=["relu", "relu"],
+            use_batch_norm=False,
+        )
         model.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         results = model.evaluate(self.X_test, self.y_test)
-        self.assertGreater(results['accuracy'], 0.8)
+        self.assertGreater(results["accuracy"], 0.8)
 
     def test_forward_propagation(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
         activations, Z_values = model.forward_propagation(self.X_train)
-        
+
         self.assertEqual(len(activations), 3)  # Input, hidden, and output layers
         self.assertEqual(activations[0].shape, self.X_train.shape)
         self.assertEqual(activations[-1].shape, self.y_train.shape)
 
     def test_backpropagation(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
         activations, Z_values = model.forward_propagation(self.X_train)
-        model.backpropagation(self.X_train, self.y_train, activations, Z_values, learning_rate=0.01)
-        
+        model.backpropagation(
+            self.X_train, self.y_train, activations, Z_values, learning_rate=0.01
+        )
+
         # Check if weights and biases are updated
         for w in model.weights:
             self.assertFalse(np.allclose(w, 0))
@@ -59,178 +85,301 @@ class TestMultiLayerANN(unittest.TestCase):
             self.assertFalse(np.allclose(b, 0))
 
     def test_predict(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
         predictions = model.predict(self.X_test)
-        
+
         self.assertEqual(predictions.shape, self.y_test.shape)
 
         def test_save_and_load_model(self):
-            model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
+            model = Multi_Layer_ANN(
+                self.X_train,
+                self.y_train,
+                hidden_layers=[5],
+                activations=["relu"],
+                use_batch_norm=True,
+            )
             model.fit(epochs=10, learning_rate=0.01, verbose=False)
-        
+
         # Save the model
-        model.save_model('test_model.npy')
-        
+        model.save_model("test_model.npy")
+
         # Create a new model and load the saved weights
-        loaded_model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                       activations=['relu'], use_batch_norm=True)
-        loaded_model.load_model('test_model.npy')
-        
+        loaded_model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
+        loaded_model.load_model("test_model.npy")
+
         # Compare predictions
         original_predictions = model.predict(self.X_test)
         loaded_predictions = loaded_model.predict(self.X_test)
-        
+
         np.testing.assert_array_almost_equal(original_predictions, loaded_predictions)
 
     def test_learning_rate_scheduler(self):
         from pydeepflow.learning_rate_scheduler import LearningRateScheduler
-        
+
         lr_scheduler = LearningRateScheduler(initial_lr=0.1, strategy="decay")
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
-        
-        model.fit(epochs=20, learning_rate=0.1, lr_scheduler=lr_scheduler, verbose=False)
-        
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
+
+        model.fit(
+            epochs=20, learning_rate=0.1, lr_scheduler=lr_scheduler, verbose=False
+        )
+
         # Check if learning rate has decreased
         self.assertLess(lr_scheduler.get_lr(19), 0.1)
 
     def test_early_stopping(self):
         from pydeepflow.early_stopping import EarlyStopping
-        
+
         early_stop = EarlyStopping(patience=5)
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
-        
-        model.fit(epochs=200, learning_rate=0.1, early_stop=early_stop,
-                  X_val=self.X_test, y_val=self.y_test, verbose=False)
-        
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
+
+        model.fit(
+            epochs=200,
+            learning_rate=0.1,
+            early_stop=early_stop,
+            X_val=self.X_test,
+            y_val=self.y_test,
+            verbose=False,
+        )
+
         # Check if training stopped early
-        self.assertLess(len(model.history['train_loss']), 100)
+        self.assertLess(len(model.history["train_loss"]), 100)
 
     def test_model_checkpointing(self):
         from pydeepflow.checkpoints import ModelCheckpoint
         import os
-        
-        checkpoint = ModelCheckpoint(save_dir='./checkpoints', monitor='val_loss', save_best_only=True)
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[5], 
-                                activations=['relu'], use_batch_norm=True)
-        
-        model.fit(epochs=20, learning_rate=0.01, checkpoint=checkpoint, 
-                  X_val=self.X_test, y_val=self.y_test, verbose=False)
-        
+
+        checkpoint = ModelCheckpoint(
+            save_dir="./checkpoints", monitor="val_loss", save_best_only=True
+        )
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[5],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
+
+        model.fit(
+            epochs=20,
+            learning_rate=0.01,
+            checkpoint=checkpoint,
+            X_val=self.X_test,
+            y_val=self.y_test,
+            verbose=False,
+        )
+
         # Check if checkpoint file was created
-        self.assertTrue(os.path.exists('./checkpoints'))
-        checkpoint_files = os.listdir('./checkpoints')
+        self.assertTrue(os.path.exists("./checkpoints"))
+        checkpoint_files = os.listdir("./checkpoints")
         self.assertTrue(len(checkpoint_files) > 0)
 
     def test_batch_norm_effect(self):
-        model_bn = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                activations=['relu', 'relu'], use_batch_norm=True)
+        model_bn = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+        )
         model_bn.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Model without batch norm
-        model_no_bn = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                      activations=['relu', 'relu'], use_batch_norm=False)
+        model_no_bn = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=False,
+        )
         model_no_bn.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Compare performance
         results_bn = model_bn.evaluate(self.X_test, self.y_test)
         results_no_bn = model_no_bn.evaluate(self.X_test, self.y_test)
-        
+
         # This test might not always pass due to the stochastic nature of training
         # but it gives an idea of the potential benefit of batch normalization
-        self.assertGreaterEqual(results_bn['accuracy'], results_no_bn['accuracy'])
+        self.assertGreaterEqual(results_bn["accuracy"], results_no_bn["accuracy"])
 
     def test_different_activations(self):
-        activations = ['relu', 'sigmoid', 'tanh']
+        activations = ["relu", "sigmoid", "tanh"]
         for activation in activations:
-            model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[10], 
-                                    activations=[activation], use_batch_norm=True)
+            model = Multi_Layer_ANN(
+                self.X_train,
+                self.y_train,
+                hidden_layers=[10],
+                activations=[activation],
+                use_batch_norm=True,
+            )
             model.fit(epochs=50, learning_rate=0.01, verbose=False)
             results = model.evaluate(self.X_test, self.y_test)
-            self.assertGreater(results['accuracy'], 0.8, f"Model with {activation} activation failed")
+            self.assertGreater(
+                results["accuracy"], 0.8, f"Model with {activation} activation failed"
+            )
 
     def test_model_history(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[10], 
-                                activations=['relu'], use_batch_norm=True)
-        model.fit(epochs=50, learning_rate=0.01, X_val=self.X_test, y_val=self.y_test, verbose=False)
-        
-        self.assertIn('train_loss', model.history)
-        self.assertIn('val_loss', model.history)
-        self.assertIn('train_accuracy', model.history)
-        self.assertIn('val_accuracy', model.history)
-        self.assertEqual(len(model.history['train_loss']), 50)
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[10],
+            activations=["relu"],
+            use_batch_norm=True,
+        )
+        model.fit(
+            epochs=50,
+            learning_rate=0.01,
+            X_val=self.X_test,
+            y_val=self.y_test,
+            verbose=False,
+        )
+
+        self.assertIn("train_loss", model.history)
+        self.assertIn("val_loss", model.history)
+        self.assertIn("train_accuracy", model.history)
+        self.assertIn("val_accuracy", model.history)
+        self.assertEqual(len(model.history["train_loss"]), 50)
 
     def test_regularization(self):
         # Model with L2 regularization
-        model_reg = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                    activations=['relu', 'relu'], use_batch_norm=True, l2_lambda=0.01)
+        model_reg = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+            l2_lambda=0.01,
+        )
         model_reg.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Model without regularization
-        model_no_reg = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                       activations=['relu', 'relu'], use_batch_norm=True, l2_lambda=0.0)
+        model_no_reg = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+            l2_lambda=0.0,
+        )
         model_no_reg.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Compare performance on test set
         results_reg = model_reg.evaluate(self.X_test, self.y_test)
         results_no_reg = model_no_reg.evaluate(self.X_test, self.y_test)
-        
+
         # Regularized model should generalize better (though this might not always be true)
-        self.assertGreaterEqual(results_reg['accuracy'], results_no_reg['accuracy'])
+        self.assertGreaterEqual(results_reg["accuracy"], results_no_reg["accuracy"])
 
     def test_dropout(self):
-        model_dropout = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                    activations=['relu', 'relu'], use_batch_norm=True, dropout_rate=0.5)
+        model_dropout = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+            dropout_rate=0.5,
+        )
         model_dropout.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Model without dropout
-        model_no_dropout = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                           activations=['relu', 'relu'], use_batch_norm=True, dropout_rate=0.0)
+        model_no_dropout = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+            dropout_rate=0.0,
+        )
         model_no_dropout.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Compare performance on test set
         results_dropout = model_dropout.evaluate(self.X_test, self.y_test)
         results_no_dropout = model_no_dropout.evaluate(self.X_test, self.y_test)
-        
+
         # Dropout should help with generalization, but due to the stochastic nature,
         # this test might not always pass. It's more of a sanity check.
-        self.assertGreaterEqual(results_dropout['accuracy'], 0.8)
-        self.assertGreaterEqual(results_no_dropout['accuracy'], 0.8)
+        self.assertGreaterEqual(results_dropout["accuracy"], 0.8)
+        self.assertGreaterEqual(results_no_dropout["accuracy"], 0.8)
 
     def test_gradient_clipping(self):
         # Model with gradient clipping
-        model_clip = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                     activations=['relu', 'relu'], use_batch_norm=True)
-        model_clip.fit(epochs=50, learning_rate=0.01, clipping_threshold=1.0, verbose=False)
-        
+        model_clip = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+        )
+        model_clip.fit(
+            epochs=50, learning_rate=0.01, clipping_threshold=1.0, verbose=False
+        )
+
         # Model without gradient clipping
-        model_no_clip = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[20, 20], 
-                                        activations=['relu', 'relu'], use_batch_norm=True)
+        model_no_clip = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[20, 20],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+        )
         model_no_clip.fit(epochs=50, learning_rate=0.01, verbose=False)
-        
+
         # Both models should converge, but the clipped model might be more stable
         results_clip = model_clip.evaluate(self.X_test, self.y_test)
         results_no_clip = model_no_clip.evaluate(self.X_test, self.y_test)
-        
-        self.assertGreaterEqual(results_clip['accuracy'], 0.8)
-        self.assertGreaterEqual(results_no_clip['accuracy'], 0.8)
-    
+
+        self.assertGreaterEqual(results_clip["accuracy"], 0.8)
+        self.assertGreaterEqual(results_no_clip["accuracy"], 0.8)
+
     def test_adam_optimizer(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[10, 10],
-                                activations=['relu', 'relu'], use_batch_norm=True, optimizer='adam')
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[10, 10],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+            optimizer="adam",
+        )
         model.fit(epochs=200, learning_rate=0.005, verbose=False)
         results = model.evaluate(self.X_test, self.y_test)
-        self.assertGreater(results['accuracy'], 0.8)
+        self.assertGreater(results["accuracy"], 0.8)
 
     def test_rmsprop_optimizer(self):
-        model = Multi_Layer_ANN(self.X_train, self.y_train, hidden_layers=[10, 10],
-                                activations=['relu', 'relu'], use_batch_norm=True, optimizer='rmsprop')
+        model = Multi_Layer_ANN(
+            self.X_train,
+            self.y_train,
+            hidden_layers=[10, 10],
+            activations=["relu", "relu"],
+            use_batch_norm=True,
+            optimizer="rmsprop",
+        )
         model.fit(epochs=200, learning_rate=0.001, verbose=False)
         results = model.evaluate(self.X_test, self.y_test)
-        self.assertGreater(results['accuracy'], 0.8)
+        self.assertGreater(results["accuracy"], 0.8)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description
This PR sets the Matplotlib backend to `"Agg"` in `model.py` to ensure compatibility with headless environments (such as servers, containers, and CI/CD pipelines). This change prevents errors related to missing GUI libraries (e.g., `gi`/GTK) and allows plots to be saved directly to files without requiring a display.

## Changes
- Added `matplotlib.use("Agg")` before importing `matplotlib.pyplot` in `model.py`.
- Ensures plotting functions work reliably in environments without a graphical interface.

## Issue
Resolves #40 

## Testing
- Verified that training history plots are generated and saved as expected.
- No errors related to Matplotlib backend or missing GUI libraries.
