### PR TITLE
feat(activations): Implement and test GELU and Swish functions

### DIFF
--- a/pydeepflow/activations.py
+++ b/pydeepflow/activations.py
@@ -56,8 +56,11 @@ def _prelu_derivative(x, device, alpha):
 def _elu_derivative(x, device, alpha):
     return device.where(x > 0, 1, alpha * device.exp(x))
 def _gelu_derivative(x, device, alpha):
-    return 0.5 * (1 + device.tanh(device.sqrt(2 / device.pi) * (x + 0.044715 * x ** 3))) + \
-            0.5 * x * (1 - device.tanh(device.sqrt(2 / device.pi) * (x + 0.044715 * x ** 3)) ** 2)
+    Z = device.sqrt(2 / np.pi) * (x + 0.044715 * (x ** 3))
+    dZ_dx = device.sqrt(2 / np.pi) * (1 + 3 * 0.044715 * (x ** 2))
+    tanh_Z = device.tanh(Z)
+    sech_Z_sq = 1 - tanh_Z**2
+    return 0.5 * (1 + tanh_Z) + 0.5 * x * sech_Z_sq * dZ_dx
 def _swish_derivative(x, device, alpha):
     sigma = 1 / (1 + device.exp(-x))
     return sigma + x * sigma * (1 - sigma)

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -27,10 +27,10 @@ class TestActivations(unittest.TestCase):
         np.testing.assert_array_equal(result, expected)
 
     def test_gelu(self):
-        x = np.array([0])
+        x = np.array([-2, -1, 0, 1, 2])
         result = activation(x, 'gelu', self.device_cpu)
-        expected = np.array([0])
-        np.testing.assert_array_almost_equal(result, expected)
+        expected = np.array([-0.045402, -0.158808, 0. , 0.841192, 1.954598])
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
 
     def test_elu(self):
         x = np.array([-1, 0, 1])
@@ -51,10 +51,10 @@ class TestActivations(unittest.TestCase):
         np.testing.assert_array_almost_equal(result, expected)
 
     def test_swish(self):
-        x = np.array([0])
+        x = np.array([-2, -1, 0, 1, 2])
         result = activation(x, 'swish', self.device_cpu)
-        expected = np.array([0])
-        np.testing.assert_array_almost_equal(result, expected)
+        expected = x * (1 / (1 + np.exp(-x))) # Consistent calculation
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
 
     def test_sigmoid(self):
         x = np.array([0])
@@ -174,6 +174,26 @@ class TestActivations(unittest.TestCase):
         result = activation_derivative(x, 'tanhshrink', self.device_cpu)
         expected = np.array([0.419974])
         np.testing.assert_array_almost_equal(result, expected, decimal=5)
+
+    def test_leaky_relu_derivative(self): 
+        x = np.array([-1, 0, 1])
+        result = activation_derivative(x, 'leaky_relu', self.device_cpu, alpha=0.01)
+        expected = np.array([0.01, 0.01, 1])
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+
+    def test_gelu_derivative(self):
+        x = np.array([-2, -1, 0, 1, 2])
+        result = activation_derivative(x, 'gelu', self.device_cpu)
+        expected = np.array([-0.086099, -0.082964,  0.5,  1.082964,  1.086099])
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+
+    def test_swish_derivative(self): 
+        x = np.array([-2, -1, 0, 1, 2])
+        sigmoid_x = 1 / (1 + np.exp(-x))
+        expected = sigmoid_x + x * sigmoid_x * (1 - sigmoid_x)
+        result = activation_derivative(x, 'swish', self.device_cpu)
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+
 
     def test_softshrink_derivative(self):
         x = np.array([-1.5, -0.5, 0.5, 1.5])


### PR DESCRIPTION
Resolves #77 
This PR adds and verifies two modern activation functions, GELU and Swish, to `pydeepflow/activations.py`.
### Changes Made
1.  **Corrected GELU Derivative:** Fixed the mathematical formula and implementation bugs in the `_gelu_derivative` function.
2.  **Updated Unit Tests:** Updated the unit tests in `tests/test_activations.py` with correct expected values for both `gelu` and `gelu_derivative` to ensure their forward and backward passes are validated.

The original code for _swish and _swish_derivative in pydeepflow/activations.py was correct from the start and didn't have any of the bugs we had to fix for GELU.
Throughout entire debugging process, none of the tests for swish or swish_derivative failed.
All requirements from the issue have been met, and all tests related to this feature now pass successfully.