### PR TITLE
Generalizes the EarlyStopping with a mode parameter 

### DIFF
--- a/pydeepflow/early_stopping.py
+++ b/pydeepflow/early_stopping.py
@@ -49,5 +49,5 @@ class EarlyStopping:
             self.counter = 0
         else:
             self.counter += 1
-            if self.counter > self.patience:
+            if self.counter >= self.patience:
                 self.early_stop = True


### PR DESCRIPTION
This PR is a Hacktoberfest contribution that generalizes the EarlyStopping with a mode parameter and corrects the patience threshold.

### Details
- **Support for `mode ('min' / 'max')`**  
  Enables the class to handle both loss (minimization) and performance metrics (maximization, e.g., accuracy, F1-score).  
  Removes the need to invert metrics manually, improving **clarity** and **flexibility**.

- **Patience threshold fix**  
  Updated the condition to `self.counter >= self.patience`, ensuring early stopping triggers exactly after the specified number of non-improving epochs and resolving a potential off-by-one error.