### PR TITLE
Feat: Add MaxPooling2D and AveragePooling2D layers

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,43 @@
+import unittest
+import numpy as np
+from pydeepflow.model import MaxPooling2D, AveragePooling2D
+
+class TestPoolingLayers(unittest.TestCase):
+
+    def test_max_pooling_forward(self):
+        pool = MaxPooling2D(pool_size=(2, 2), stride=2)
+        X = np.arange(16).reshape(1, 4, 4, 1)
+        out = pool.forward(X)
+        expected_out = np.array([[[[ 5.], [ 7.]],[[13.], [15.]]]])
+        self.assertEqual(out.shape, (1, 2, 2, 1))
+        np.testing.assert_array_almost_equal(out, expected_out)
+
+    def test_max_pooling_backward(self):
+        pool = MaxPooling2D(pool_size=(2, 2), stride=2)
+        X = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], dtype=np.float32).reshape(1, 4, 4, 1)
+        pool.forward(X)
+        dOut = np.ones((1, 2, 2, 1))
+        dX = pool.backward(dOut)
+        expected_dX = np.array([[0,0,0,0],[0,1,0,1],[0,0,0,0],[0,1,0,1]], dtype=np.float32).reshape(1, 4, 4, 1)
+        np.testing.assert_array_almost_equal(dX, expected_dX)
+
+    def test_avg_pooling_forward(self):
+        pool = AveragePooling2D(pool_size=(2, 2), stride=2)
+        X = np.arange(16).reshape(1, 4, 4, 1)
+        out = pool.forward(X)
+        expected_out = np.array([[[[ 2.5], [ 4.5]],[[10.5], [12.5]]]])
+        self.assertEqual(out.shape, (1, 2, 2, 1))
+        np.testing.assert_array_almost_equal(out, expected_out)
+
+    def test_avg_pooling_backward(self):
+        pool = AveragePooling2D(pool_size=(2, 2), stride=2)
+        X = np.arange(16).reshape(1, 4, 4, 1)
+        pool.forward(X)
+        dOut = np.ones((1, 2, 2, 1))
+        dX = pool.backward(dOut)
+        expected_dX = np.ones((4, 4)) * 0.25
+        expected_dX = expected_dX.reshape(1, 4, 4, 1)
+        np.testing.assert_array_almost_equal(dX, expected_dX)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## **Description**

This pull request introduces `MaxPooling2D` and `AveragePooling2D` layers to the `PyDeepFlow` library. These are essential components for building modern Convolutional Neural Networks (CNNs) and are crucial for down-sampling feature maps, reducing computational complexity, and improving translation invariance.

This enhancement significantly improves the capabilities of `PyDeepFlow` for computer vision tasks.

## **Changes Made**

-   **`MaxPooling2D` Layer**: Implemented a new `MaxPooling2D` class with both `forward` and `backward` passes. The forward pass caches the indices of max values for correct gradient routing during backpropagation.
-   **`AveragePooling2D` Layer**: Implemented a new `AveragePooling2D` class. The backward pass correctly distributes the gradient equally across the pooling window.
-   **Integration with `Multi_Layer_CNN`**: Updated the `Multi_Layer_CNN` class to recognize and handle `'maxpool'` and `'avgpool'` as valid layer types in the model architecture definition.
-   **Validator Update**: Updated the `ModelValidator` to include `'maxpool'` and `'avgpool'` as valid layer types.
-   **Unit Tests**: Added a new test file, `tests/test_layers.py`, with comprehensive unit tests for both pooling layers to ensure the correctness of the forward and backward passes.

### **How to Test**

The new layers can be verified by running the new unit tests from the project's root directory:

```bash
python -m unittest tests/test_layers.py
```

**Closes:** #108 